### PR TITLE
Move public app routes under the 'site' route

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -392,7 +392,7 @@ class Module extends AbstractModule
     public function setPublicAppLayout(Event $event)
     {
         $routeName = $event->getRouteMatch()->getMatchedRouteName();
-        if (0 !== strpos($routeName, 'scripto')) {
+        if (0 !== strpos($routeName, 'site/scripto')) {
             // Not a public application Scripto route.
             return;
         }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -90,293 +90,281 @@ return [
     ],
     'router' => [
         'routes' => [
-            'scripto' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id][/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+            'site' => [
+                'child_routes' => [
+                    'scripto' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'index',
+                                'action' => 'index',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'index',
-                        'action' => 'index',
+                    'scripto-user-contributions' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/user/:user-id/contributions',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'user',
+                                'action' => 'contributions',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-user-contributions' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/user/:user-id/contributions',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
+                    'scripto-user-watchlist' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/user/:user-id/watchlist',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'user',
+                                'action' => 'watchlist',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'user',
-                        'action' => 'contributions',
+                    'scripto-project' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/project[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'project',
+                                'action' => 'browse',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-user-watchlist' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/user/:user-id/watchlist',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
+                    'scripto-project-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'project',
+                                'action' => 'show',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'user',
-                        'action' => 'watchlist',
+                    'scripto-item' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/item[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'item',
+                                'action' => 'browse',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-project' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/project[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'scripto-item-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'item',
+                                'action' => 'show',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'project',
-                        'action' => 'browse',
+                    'scripto-media' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/media[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'media',
+                                'action' => 'browse',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-project-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'scripto-media-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'media',
+                                'action' => 'show',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'project',
-                        'action' => 'show',
+                    'scripto-revision' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/revision[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'browse',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-item' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/item[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'scripto-revision-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/revision/:revision-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'revision-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'show',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'item',
-                        'action' => 'browse',
+                    'scripto-revision-compare' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/revision/:from-revision-id/:to-revision-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'from-revision-id' => '\d+',
+                                'to-revision-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'compare',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-item-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'scripto-talk-media-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/talk[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'media',
+                                'action' => 'show-talk',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'item',
-                        'action' => 'show',
+                    'scripto-talk-revision' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/talk/revision[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'browse-talk',
+                            ],
+                        ],
                     ],
-                ],
-            ],
-            'scripto-media' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/media[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                    'scripto-talk-revision-id' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/talk/revision/:revision-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'revision-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'show-talk',
+                            ],
+                        ],
                     ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'media',
-                        'action' => 'browse',
-                    ],
-                ],
-            ],
-            'scripto-media-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'media',
-                        'action' => 'show',
-                    ],
-                ],
-            ],
-            'scripto-revision' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/revision[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'browse',
-                    ],
-                ],
-            ],
-            'scripto-revision-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/revision/:revision-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'revision-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'show',
-                    ],
-                ],
-            ],
-            'scripto-revision-compare' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/revision/:from-revision-id/:to-revision-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'from-revision-id' => '\d+',
-                        'to-revision-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'compare',
-                    ],
-                ],
-            ],
-            'scripto-talk-media-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/talk[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'media',
-                        'action' => 'show-talk',
-                    ],
-                ],
-            ],
-            'scripto-talk-revision' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/talk/revision[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'browse-talk',
-                    ],
-                ],
-            ],
-            'scripto-talk-revision-id' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/talk/revision/:revision-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'revision-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'show-talk',
-                    ],
-                ],
-            ],
-            'scripto-talk-revision-compare' => [
-                'type' => 'Segment',
-                'options' => [
-                    'route' => '/scripto[/s/:site-slug/:site-project-id]/:project-id/:item-id/:media-id/talk/revision/:from-revision-id/:to-revision-id[/:action]',
-                    'constraints' => [
-                        'site-slug' => '[a-zA-Z0-9_-]+',
-                        'site-project-id' => '\d+',
-                        'project-id' => '\d+',
-                        'item-id' => '\d+',
-                        'media-id' => '\d+',
-                        'from-revision-id' => '\d+',
-                        'to-revision-id' => '\d+',
-                        'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                    ],
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
-                        'controller' => 'revision',
-                        'action' => 'compare-talk',
+                    'scripto-talk-revision-compare' => [
+                        'type' => 'Segment',
+                        'options' => [
+                            'route' => '/scripto/:site-project-id/:project-id/:item-id/:media-id/talk/revision/:from-revision-id/:to-revision-id[/:action]',
+                            'constraints' => [
+                                'site-project-id' => '\d+',
+                                'project-id' => '\d+',
+                                'item-id' => '\d+',
+                                'media-id' => '\d+',
+                                'from-revision-id' => '\d+',
+                                'to-revision-id' => '\d+',
+                                'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
+                            ],
+                            'defaults' => [
+                                '__NAMESPACE__' => 'Scripto\Controller\PublicApp',
+                                'controller' => 'revision',
+                                'action' => 'compare-talk',
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/src/Api/Representation/ScriptoItemRepresentation.php
+++ b/src/Api/Representation/ScriptoItemRepresentation.php
@@ -21,7 +21,7 @@ class ScriptoItemRepresentation extends AbstractEntityRepresentation
         }
         $urlHelper = $this->getViewHelper('Url');
         return $urlHelper(
-            'scripto-item-id',
+            'site/scripto-item-id',
             [
                 'action' => $action,
                 'project-id' => $this->resource->getScriptoProject()->getId(),

--- a/src/Api/Representation/ScriptoMediaRepresentation.php
+++ b/src/Api/Representation/ScriptoMediaRepresentation.php
@@ -22,7 +22,7 @@ class ScriptoMediaRepresentation extends AbstractEntityRepresentation
         }
         $urlHelper = $this->getViewHelper('Url');
         return $urlHelper(
-            'scripto-media-id',
+            'site/scripto-media-id',
             [
                 'action' => $action,
                 'project-id' => $this->resource->getScriptoItem()->getScriptoProject()->getId(),

--- a/src/Api/Representation/ScriptoProjectRepresentation.php
+++ b/src/Api/Representation/ScriptoProjectRepresentation.php
@@ -13,7 +13,7 @@ class ScriptoProjectRepresentation extends AbstractEntityRepresentation
         }
         $urlHelper = $this->getViewHelper('Url');
         return $urlHelper(
-            'scripto-project-id',
+            'site/scripto-project-id',
             [
                 'action' => $action,
                 'project-id' => $this->resource->getId(),

--- a/src/Controller/PublicApp/IndexController.php
+++ b/src/Controller/PublicApp/IndexController.php
@@ -13,6 +13,7 @@ class IndexController extends AbstractActionController
         $userInfo = $this->scripto()->apiClient()->queryUserInfo();
         $user = $this->scripto()->apiClient()->queryUser($userInfo['name']);
 
+
         $userCons = [];
         $watchlist = [];
         if ($this->scripto()->apiClient()->userIsLoggedIn()) {
@@ -49,7 +50,7 @@ class IndexController extends AbstractActionController
                         $formData['email'], $formData['realname']
                     );
                     $this->messenger()->addSuccess('Your Scripto account has been created! Please check your email for a link to activate your account.'); // @translate
-                    return $this->redirect()->toRoute('scripto');
+                    return $this->redirect()->toRoute('site/scripto');
                 } catch (CreateaccountException $e) {
                     $this->messenger()->addError($e->getMessage());
                 }

--- a/src/Controller/PublicApp/ItemController.php
+++ b/src/Controller/PublicApp/ItemController.php
@@ -10,7 +10,7 @@ class ItemController extends AbstractActionController
     {
         $project = $this->scripto()->getRepresentation($this->params('project-id'));
         if (!$project) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $this->setBrowseDefaults('id');
@@ -39,7 +39,7 @@ class ItemController extends AbstractActionController
     public function showAction()
     {
         return $this->redirect()->toRoute(
-            'scripto-media',
+            'site/scripto-media',
             ['action' => 'browse'],
             ['query' => $this->params()->fromQuery()],
             true

--- a/src/Controller/PublicApp/MediaController.php
+++ b/src/Controller/PublicApp/MediaController.php
@@ -14,7 +14,7 @@ class MediaController extends AbstractActionController
             $this->params('item-id')
         );
         if (!$sItem) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $this->setBrowseDefaults('position', 'asc');
@@ -102,7 +102,7 @@ class MediaController extends AbstractActionController
             $this->params('media-id')
         );
         if (!$sMedia) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $sItem = $sMedia->scriptoItem();
@@ -133,7 +133,7 @@ class MediaController extends AbstractActionController
             $this->params('media-id')
         );
         if (!$sMedia) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $action = (0 === $namespace) ? 'show' : 'talk';

--- a/src/Controller/PublicApp/ProjectController.php
+++ b/src/Controller/PublicApp/ProjectController.php
@@ -22,7 +22,7 @@ class ProjectController extends AbstractActionController
     {
         $project = $this->scripto()->getRepresentation($this->params('project-id'));
         if (!$project) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $view = new ViewModel;
@@ -34,7 +34,7 @@ class ProjectController extends AbstractActionController
     public function showAction()
     {
         return $this->redirect()->toRoute(
-            'scripto-item',
+            'site/scripto-item',
             ['action' => 'browse'],
             ['query' => $this->params()->fromQuery()],
             true

--- a/src/Controller/PublicApp/RevisionController.php
+++ b/src/Controller/PublicApp/RevisionController.php
@@ -50,7 +50,7 @@ class RevisionController extends AbstractActionController
             $this->params('media-id')
         );
         if (!$sMedia) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $response = $sMedia->pageRevisions($namespace, 100, $this->params()->fromQuery('continue'));
@@ -87,7 +87,7 @@ class RevisionController extends AbstractActionController
             $this->params('media-id')
         );
         if (!$sMedia) {
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         try {

--- a/src/Controller/PublicApp/UserController.php
+++ b/src/Controller/PublicApp/UserController.php
@@ -32,14 +32,14 @@ class UserController extends AbstractActionController
     {
         if (!$this->scripto()->apiClient()->userIsLoggedIn()) {
             // User must be logged in.
-            return $this->redirect()->toRoute('scripto');
+            return $this->redirect()->toRoute('site/scripto');
         }
 
         $userName = $this->params('user-id');
         $currentUser = $this->scripto()->apiClient()->queryUserInfo();
         if ($userName !== $currentUser['name']) {
             // Logged in user must be current user.
-            return $this->redirect()->toRoute('scripto-user-watchlist', ['user-id' => $currentUser['name']]);
+            return $this->redirect()->toRoute('site/scripto-user-watchlist', ['user-id' => $currentUser['name']]);
         }
 
         $hours = $this->params()->fromQuery('hours', 720); // 30 days

--- a/src/Site/Navigation/Link/Scripto.php
+++ b/src/Site/Navigation/Link/Scripto.php
@@ -42,7 +42,7 @@ class Scripto implements LinkInterface
     public function toZend(array $data, SiteRepresentation $site)
     {
         return [
-            'route' => 'scripto-project-id',
+            'route' => 'site/scripto-project-id',
             'params' => [
                 'site-slug' => $site->slug(),
                 'site-project-id' => $data['project_id'],

--- a/src/ViewHelper/Scripto.php
+++ b/src/ViewHelper/Scripto.php
@@ -123,7 +123,7 @@ class Scripto extends AbstractHelper
             ? $this->publicAppProject->link($view->translate('Project'), null, ['class' => 'page-link'])
             : $view->hyperlink(
                 $view->translate('Projects'),
-                $view->url('scripto-project', ['action' => 'browse'], true),
+                $view->url('site/scripto-project', ['action' => 'browse'], true),
                 ['class' => 'page-link']
             );
     }
@@ -263,7 +263,7 @@ class Scripto extends AbstractHelper
             $userInfo = $this->apiClient->queryUserInfo();
             $form = $this->formElementManager->get(ScriptoLogoutForm::class);
             $form->setAttribute('action', $view->url(
-                'scripto',
+                'site/scripto',
                 ['action' => 'logout'],
                 ['query' => ['redirect' => $this->getCurrentUrl()]]
             ));
@@ -280,17 +280,18 @@ class Scripto extends AbstractHelper
                 %s',
                 $view->translate('User menu'), // @translate
                 sprintf($view->translate('Logged in to Scripto as %s'), sprintf('<span class="username">%s</span>', $userInfo['name'])),
-                $view->hyperlink($view->translate('Dashboard'), $view->url('scripto', ['action' => 'index'], true)),
-                $view->hyperlink($view->translate('Contributions'), $view->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $userInfo['name']], true)),
-                $view->hyperlink($view->translate('Watchlist'), $view->url('scripto-user-watchlist', ['action' => 'watchlist', 'user-id' => $userInfo['name']], true)),
+                $view->hyperlink($view->translate('Dashboard'), $view->url('site/scripto', ['action' => 'index'], true)),
+                $view->hyperlink($view->translate('Contributions'), $view->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $userInfo['name']], true)),
+                $view->hyperlink($view->translate('Watchlist'), $view->url('site/scripto-user-watchlist', ['action' => 'watchlist', 'user-id' => $userInfo['name']], true)),
                 $view->form($form)
             );
         } else {
             $form = $this->formElementManager->get(ScriptoLoginForm::class);
             $form->setAttribute('action', $view->url(
-                'scripto',
+                'site/scripto',
                 ['action' => 'login'],
-                ['query' => ['redirect' => $this->getCurrentUrl()]]
+                ['query' => ['redirect' => $this->getCurrentUrl()]],
+                true
             ));
             return sprintf(
                 '<div class="user logged-out"><a href="#" class="user-toggle page-link menu-toggle">%s</a><div class="user-menu">%s</div></div>',
@@ -609,7 +610,7 @@ HTML;
         $userInfo = $this->apiClient->queryUserInfo();
         return sprintf(
             '-- [%s %s] ~~~~~',
-            $view->url('scripto-user-contributions', ['user-id' => $userInfo['name']], ['force_canonical' => true]),
+            $view->url('site/scripto-user-contributions', ['user-id' => $userInfo['name']], ['force_canonical' => true], true),
             $userInfo['name']
         );
     }

--- a/view/common/block-layout/scripto-block.phtml
+++ b/view/common/block-layout/scripto-block.phtml
@@ -2,7 +2,7 @@
 <p><?php echo $this->hyperlink(
     $project->title(),
     $this->url(
-        'scripto-project-id',
+        'site/scripto-project-id',
         [
             'site-slug' => $site->slug(),
             'site-project-id' => $project->id(),

--- a/view/common/media-head.phtml
+++ b/view/common/media-head.phtml
@@ -2,7 +2,7 @@
     <div class="tab-actions">
     <?php if ($userCanEdit): ?>
         <?php echo $sMedia->link($this->scripto()->translate($project->contentType(), 'Edit'), 'edit'); ?>
-        <?php echo $this->hyperlink($this->translate('Browse revision history'), $this->url('scripto-revision', ['action' => 'browse'], true)); ?>
+        <?php echo $this->hyperlink($this->translate('Browse revision history'), $this->url('site/scripto-revision', ['action' => 'browse'], true)); ?>
     <?php endif; ?>
     <?php echo $sMedia->link($this->translate('View notes'), 'show-talk'); ?>
     <?php echo $this->scripto()->watchlistToggle($sMedia, $project->mediaType()); ?>

--- a/view/layout/layout-scripto-public-app.phtml
+++ b/view/layout/layout-scripto-public-app.phtml
@@ -25,7 +25,7 @@ $this->headScript()->appendFile($this->assetUrl('js/public-app.js', 'Scripto'));
     </head>
     <header class="site-header" role="banner">
         <div class="wrapper">
-            <?php echo $this->hyperlink($title, $this->url('scripto', ['action' => 'index'], true), ['class' => 'site-title']); ?>
+            <?php echo $this->hyperlink($title, $this->url('site/scripto', ['action' => 'index'], true), ['class' => 'site-title']); ?>
             <nav class="top-nav">
                 <input type="checkbox" id="nav-trigger" class="nav-trigger" aria-label="<?php echo $this->translate('Toggle menu'); ?>"/>
                 <label for="nav-trigger">
@@ -37,7 +37,7 @@ $this->headScript()->appendFile($this->assetUrl('js/public-app.js', 'Scripto'));
                         <?php echo $this->scripto()->publicAppSiteLink(); ?>
                         <?php echo $this->scripto()->loginBar(); ?>
                         <?php if (!$this->scripto()->apiClient()->userIsLoggedIn()): ?>
-                        <?php echo $this->hyperlink($this->translate('Create account'), $this->url('scripto', ['action' => 'create-account'], true), ['class' => 'page-link']); ?>
+                        <?php echo $this->hyperlink($this->translate('Create account'), $this->url('site/scripto', ['action' => 'create-account'], true), ['class' => 'page-link']); ?>
                         <?php endif; ?>
                     </div>
                     <?php if (isset($project)): ?>

--- a/view/scripto/public-app/index/index.phtml
+++ b/view/scripto/public-app/index/index.phtml
@@ -2,7 +2,7 @@
         <h4>
             <?php echo $this->translate('Your recent contributions'); ?>
             <?php if (!isset($user['invalid'])): ?>
-            <?php echo $this->hyperlink($this->translate('View your contributions'), $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $user['name']], true), ['class' => 'button']); ?>
+            <?php echo $this->hyperlink($this->translate('View your contributions'), $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $user['name']], true), ['class' => 'button']); ?>
             <?php endif; ?>
         </h4>
         <?php if (!isset($user['invalid']) && $userCons): ?>
@@ -27,7 +27,7 @@
                     '%s: %s (%s) (%s | %s) %s (%s) <i>%s</i>',
                     $this->scripto()->translate($project->itemType(), 'Item'),
                     $this->hyperlink($sItem->item()->displayTitle(), $this->url(
-                        $isTalk ? 'scripto-talk-media-id' : 'scripto-media-id',
+                        $isTalk ? 'site/scripto-talk-media-id' : 'site/scripto-media-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),
@@ -41,7 +41,7 @@
                         : sprintf($this->scripto()->translate($project->mediaType(), 'Media #%s'), $sMedia->position()),
                     $userCon['parentid']
                         ? $this->hyperlink($this->translate('diff'), $this->url(
-                            $isTalk ? 'scripto-talk-revision-compare' : 'scripto-revision-compare',
+                            $isTalk ? 'site/scripto-talk-revision-compare' : 'site/scripto-revision-compare',
                             [
                                 'action' => 'compare',
                                 'project-id' => $project->id(),
@@ -54,7 +54,7 @@
                         ))
                         : $this->translate('diff'),
                     $this->hyperlink($this->translate('hist'), $this->url(
-                        $isTalk ? 'scripto-talk-revision' : 'scripto-revision',
+                        $isTalk ? 'site/scripto-talk-revision' : 'site/scripto-revision',
                         [
                             'action' => 'browse',
                             'project-id' => $project->id(),
@@ -64,7 +64,7 @@
                         true
                     )),
                     $this->hyperlink($date, $this->url(
-                        $isTalk ? 'scripto-talk-revision-id' : 'scripto-revision-id',
+                        $isTalk ? 'site/scripto-talk-revision-id' : 'site/scripto-revision-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),
@@ -96,7 +96,7 @@
         <h4>
             <?php echo $this->translate('Your recent watchlist'); ?>
             <?php if (!isset($user['invalid'])): ?>
-            <?php echo $this->hyperlink($this->translate('View your watchlist'), $this->url('scripto-user-watchlist', ['action' => 'watchlist', 'user-id' => $user['name']], true), ['class' => 'button']); ?>
+            <?php echo $this->hyperlink($this->translate('View your watchlist'), $this->url('site/scripto-user-watchlist', ['action' => 'watchlist', 'user-id' => $user['name']], true), ['class' => 'button']); ?>
             <?php endif; ?>
         </h4>
         <?php if (!isset($user['invalid']) && $watchlist): ?>
@@ -122,7 +122,7 @@
                     '%s: %s (%s) (%s | %s) %s (%s) <i>%s</i>',
                     $this->scripto()->translate($project->itemType(), 'Item'),
                     $this->hyperlink($sItem->item()->displayTitle(), $this->url(
-                        $isTalk ? 'scripto-talk-media-id' : 'scripto-media-id',
+                        $isTalk ? 'site/scripto-talk-media-id' : 'site/scripto-media-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),
@@ -136,7 +136,7 @@
                         : sprintf($this->scripto()->translate($project->mediaType(), 'Media #%s'), $sMedia->position()),
                     $page['old_revid']
                         ? $this->hyperlink($this->translate('diff'), $this->url(
-                            $isTalk ? 'scripto-talk-revision-compare' : 'scripto-revision-compare',
+                            $isTalk ? 'site/scripto-talk-revision-compare' : 'site/scripto-revision-compare',
                             [
                                 'action' => 'compare',
                                 'project-id' => $project->id(),
@@ -149,7 +149,7 @@
                         ))
                         : $this->translate('diff'),
                     $this->hyperlink($this->translate('hist'), $this->url(
-                        $isTalk ? 'scripto-talk-revision' : 'scripto-revision',
+                        $isTalk ? 'site/scripto-talk-revision' : 'site/scripto-revision',
                         [
                             'action' => 'browse',
                             'project-id' => $project->id(),
@@ -159,7 +159,7 @@
                         true
                     )),
                     $this->hyperlink($date, $this->url(
-                        $isTalk ? 'scripto-talk-revision-id' : 'scripto-revision-id',
+                        $isTalk ? 'site/scripto-talk-revision-id' : 'site/scripto-revision-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),

--- a/view/scripto/public-app/media/show-talk.phtml
+++ b/view/scripto/public-app/media/show-talk.phtml
@@ -38,7 +38,7 @@ $this->scripto()->postSubtitle(sprintf($this->translate('Original title: %s'), $
         <ul class="note-actions">
         <?php if ($userCanEdit): ?>
             <li><?php echo $sMedia->link($this->translate('Edit'), 'edit-talk'); ?></li>
-            <li><?php echo $this->hyperlink($this->translate('Browse notes history'), $this->url('scripto-talk-revision', ['action' => 'browse-talk'], true)); ?></li>
+            <li><?php echo $this->hyperlink($this->translate('Browse notes history'), $this->url('site/scripto-talk-revision', ['action' => 'browse-talk'], true)); ?></li>
         <?php endif; ?>
         </ul>
     </div>

--- a/view/scripto/public-app/revision/browse-talk.phtml
+++ b/view/scripto/public-app/revision/browse-talk.phtml
@@ -33,10 +33,10 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                             <?php echo sprintf(
                                 '%s | %s',
                                 $latestId !== $revision['revid']
-                                    ? $this->hyperlink($this->translate('cur'), $this->url('scripto-talk-revision-compare', ['action' => 'compare-talk', 'from-revision-id' => $revision['revid'], 'to-revision-id' => $latestId], true))
+                                    ? $this->hyperlink($this->translate('cur'), $this->url('site/scripto-talk-revision-compare', ['action' => 'compare-talk', 'from-revision-id' => $revision['revid'], 'to-revision-id' => $latestId], true))
                                     : $this->translate('cur'),
                                 $childRevision
-                                    ? $this->hyperlink($this->translate('prev'), $this->url('scripto-talk-revision-compare', ['action' => 'compare-talk', 'from-revision-id' => $childRevision['revid'], 'to-revision-id' => $revision['revid']], true))
+                                    ? $this->hyperlink($this->translate('prev'), $this->url('site/scripto-talk-revision-compare', ['action' => 'compare-talk', 'from-revision-id' => $childRevision['revid'], 'to-revision-id' => $revision['revid']], true))
                                     : $this->translate('prev')
                             ); ?>
                             </div>
@@ -56,7 +56,7 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                     <td>
                         <?php echo $this->hyperlink(
                             $revision['timestamp']->format('G:i:s, j F Y'),
-                            $this->url('scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $revision['revid']], true)
+                            $this->url('site/scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $revision['revid']], true)
                         ); ?>
                         <?php if ($revision['revid'] === $sMedia->completedRevision()): ?>
                         <div class="green">This revision marked as completed.</div>
@@ -65,7 +65,7 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                         <div class="green">This revision marked as approved.</div>
                         <?php endif; ?>
                     </td>
-                    <td><?php echo $this->hyperlink($revision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true)); ?></td>
+                    <td><?php echo $this->hyperlink($revision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true)); ?></td>
                     <td><?php
                     $sizeDiff = $childRevision ? $revision['size'] - $childRevision['size'] : 0;
                     echo sprintf(

--- a/view/scripto/public-app/revision/browse.phtml
+++ b/view/scripto/public-app/revision/browse.phtml
@@ -32,10 +32,10 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                             <?php echo sprintf(
                                 '%s | %s',
                                 $latestId !== $revision['revid']
-                                    ? $this->hyperlink($this->translate('cur'), $this->url('scripto-revision-compare', ['action' => 'compare', 'from-revision-id' => $revision['revid'], 'to-revision-id' => $latestId], true))
+                                    ? $this->hyperlink($this->translate('cur'), $this->url('site/scripto-revision-compare', ['action' => 'compare', 'from-revision-id' => $revision['revid'], 'to-revision-id' => $latestId], true))
                                     : $this->translate('cur'),
                                 $childRevision
-                                    ? $this->hyperlink($this->translate('prev'), $this->url('scripto-revision-compare', ['action' => 'compare', 'from-revision-id' => $childRevision['revid'], 'to-revision-id' => $revision['revid']], true))
+                                    ? $this->hyperlink($this->translate('prev'), $this->url('site/scripto-revision-compare', ['action' => 'compare', 'from-revision-id' => $childRevision['revid'], 'to-revision-id' => $revision['revid']], true))
                                     : $this->translate('prev')
                             ); ?>
                             </div>
@@ -55,7 +55,7 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                     <td>
                         <?php echo $this->hyperlink(
                             $revision['timestamp']->format('G:i:s, j F Y'),
-                            $this->url('scripto-revision-id', ['action' => 'show', 'revision-id' => $revision['revid']], true)
+                            $this->url('site/scripto-revision-id', ['action' => 'show', 'revision-id' => $revision['revid']], true)
                         ); ?>
                         <?php if ($revision['revid'] === $sMedia->completedRevision()): ?>
                         <div class="green">This revision marked as completed.</div>
@@ -64,7 +64,7 @@ $this->scripto()->postSubtitle($sMedia->link($media->displayTitle(), 'show-talk'
                         <div class="green">This revision marked as approved.</div>
                         <?php endif; ?>
                     </td>
-                    <td><?php echo $this->hyperlink($revision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true)); ?></td>
+                    <td><?php echo $this->hyperlink($revision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true)); ?></td>
                     <td><?php
                     $sizeDiff = $childRevision ? $revision['size'] - $childRevision['size'] : 0;
                     echo sprintf(

--- a/view/scripto/public-app/revision/compare-talk.phtml
+++ b/view/scripto/public-app/revision/compare-talk.phtml
@@ -3,7 +3,7 @@ $this->scripto()->postTitle(sprintf($this->translate('Compare note revisions: %s
 ?>
 <div class="resource-content">
     <div class="browse-controls">
-        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('scripto-talk-revision', ['action' => 'browse'], true)); ?>
+        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('site/scripto-talk-revision', ['action' => 'browse'], true)); ?>
         <?php echo $this->scripto()->compareRevisionsPagination(); ?>
     </div>
     <table id="compare-table">
@@ -16,20 +16,20 @@ $this->scripto()->postTitle(sprintf($this->translate('Compare note revisions: %s
         <thead>
             <tr>
                 <th colspan="2">
-                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $fromRevision['timestamp']->format('G:i:s, j F Y')), $this->url('scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $fromRevision['revid']], true)); ?>
+                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $fromRevision['timestamp']->format('G:i:s, j F Y')), $this->url('site/scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $fromRevision['revid']], true)); ?>
                     <?php echo sprintf(
                         $this->translate('by %s'),
-                        $this->hyperlink($fromRevision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $fromRevision['user']], true))
+                        $this->hyperlink($fromRevision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $fromRevision['user']], true))
                     ); ?></div>
                     <?php if ($fromRevision['parsedcomment']): ?>
                     <div class="parsed-comment"><?php echo strip_tags($fromRevision['parsedcomment']); ?></div>
                     <?php endif; ?>
                 </th>
                 <th colspan="2">
-                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $toRevision['timestamp']->format('G:i:s, j F Y')), $this->url('scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $toRevision['revid']], true)); ?>
+                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $toRevision['timestamp']->format('G:i:s, j F Y')), $this->url('site/scripto-talk-revision-id', ['action' => 'show-talk', 'revision-id' => $toRevision['revid']], true)); ?>
                     <?php echo sprintf(
                         $this->translate('by %s'),
-                        $this->hyperlink($toRevision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $toRevision['user']], true))
+                        $this->hyperlink($toRevision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $toRevision['user']], true))
                     ); ?></div>
                     <?php if ($toRevision['parsedcomment']): ?>
                     <div class="parsed-comment"><?php echo strip_tags($toRevision['parsedcomment']); ?></div>

--- a/view/scripto/public-app/revision/compare.phtml
+++ b/view/scripto/public-app/revision/compare.phtml
@@ -3,7 +3,7 @@ $this->scripto()->postTitle(sprintf($this->translate('Compare revisions: %s'), $
 ?>
 <div class="resource-content">
     <div class="browse-controls">
-        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('scripto-revision', ['action' => 'browse'], true)); ?>
+        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('site/scripto-revision', ['action' => 'browse'], true)); ?>
         <?php echo $this->scripto()->compareRevisionsPagination(); ?>
     </div>
     <table id="compare-table">
@@ -16,20 +16,20 @@ $this->scripto()->postTitle(sprintf($this->translate('Compare revisions: %s'), $
         <thead>
             <tr>
                 <th colspan="2">
-                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $fromRevision['timestamp']->format('G:i:s, j F Y')), $this->url('scripto-revision-id', ['action' => 'show', 'revision-id' => $fromRevision['revid']], true)); ?>
+                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $fromRevision['timestamp']->format('G:i:s, j F Y')), $this->url('site/scripto-revision-id', ['action' => 'show', 'revision-id' => $fromRevision['revid']], true)); ?>
                     <?php echo sprintf(
                         $this->translate('by %s'),
-                        $this->hyperlink($fromRevision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $fromRevision['user']], true))
+                        $this->hyperlink($fromRevision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $fromRevision['user']], true))
                     ); ?></div>
                     <?php if ($fromRevision['parsedcomment']): ?>
                     <div class="parsed-comment"><?php echo strip_tags($fromRevision['parsedcomment']); ?></div>
                     <?php endif; ?>
                 </th>
                 <th colspan="2">
-                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $toRevision['timestamp']->format('G:i:s, j F Y')), $this->url('scripto-revision-id', ['action' => 'show', 'revision-id' => $toRevision['revid']], true)); ?>
+                    <div class="revision-timestamp"><?php echo $this->hyperlink(sprintf($this->translate('Revision as of %s'), $toRevision['timestamp']->format('G:i:s, j F Y')), $this->url('site/scripto-revision-id', ['action' => 'show', 'revision-id' => $toRevision['revid']], true)); ?>
                     <?php echo sprintf(
                         $this->translate('by %s'),
-                        $this->hyperlink($toRevision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $toRevision['user']], true))
+                        $this->hyperlink($toRevision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $toRevision['user']], true))
                     ); ?></div>
                     <?php if ($toRevision['parsedcomment']): ?>
                     <div class="parsed-comment"><?php echo strip_tags($toRevision['parsedcomment']); ?></div>

--- a/view/scripto/public-app/revision/show-talk.phtml
+++ b/view/scripto/public-app/revision/show-talk.phtml
@@ -3,12 +3,12 @@ $this->scripto()->postTitle(sprintf($this->translate('Notes revision: %s'), $sMe
 $this->scripto()->postSubtitle(sprintf(
     $this->translate('Revision as of %s by %s'),
     $revision['timestamp']->format('G:i:s, j F Y'),
-    $this->hyperlink($revision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true))
+    $this->hyperlink($revision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true))
 ));
 ?>
 <div class="resource-content">
     <div class="browse-controls">
-        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('scripto-talk-revision', ['action' => 'browse'], true)); ?>
+        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('site/scripto-talk-revision', ['action' => 'browse'], true)); ?>
     </div>
     <div class="media wikitext">
         <h3><?php echo $this->translate('Wikitext'); ?></h3>

--- a/view/scripto/public-app/revision/show.phtml
+++ b/view/scripto/public-app/revision/show.phtml
@@ -3,12 +3,12 @@ $this->scripto()->postTitle(sprintf($this->translate('Revision: %s'), $sMedia->l
 $this->scripto()->postSubtitle(sprintf(
     $this->translate('Revision as of %s by %s'),
     $revision['timestamp']->format('G:i:s, j F Y'),
-    $this->hyperlink($revision['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true))
+    $this->hyperlink($revision['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $revision['user']], true))
 ));
 ?>
 <div class="resource-content">
     <div class="browse-controls">
-        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('scripto-revision', ['action' => 'browse'], true)); ?>
+        <?php echo $this->hyperlink($this->translate('Return to revision history'), $this->url('site/scripto-revision', ['action' => 'browse'], true)); ?>
     </div>
     <div class="media wikitext">
         <h3><?php echo $this->translate('Wikitext'); ?></h3>

--- a/view/scripto/public-app/user/contributions.phtml
+++ b/view/scripto/public-app/user/contributions.phtml
@@ -35,7 +35,7 @@ $this->scripto()->postTitle(sprintf($this->translate('Contributions by %s'), $us
                 <td class="revision">
                     <?php echo $sMedia
                     ? $this->hyperlink($date, $this->url(
-                        $isTalk ? 'scripto-talk-revision-id' : 'scripto-revision-id',
+                        $isTalk ? 'site/scripto-talk-revision-id' : 'site/scripto-revision-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),
@@ -54,7 +54,7 @@ $this->scripto()->postTitle(sprintf($this->translate('Contributions by %s'), $us
                         '(%s | %s)',
                         $userCon['parentid']
                             ? $this->hyperlink($this->translate('diff'), $this->url(
-                                $isTalk ? 'scripto-talk-revision-compare' : 'scripto-revision-compare',
+                                $isTalk ? 'site/scripto-talk-revision-compare' : 'site/scripto-revision-compare',
                                 [
                                     'action' => 'compare',
                                     'project-id' => $project->id(),
@@ -67,7 +67,7 @@ $this->scripto()->postTitle(sprintf($this->translate('Contributions by %s'), $us
                             ))
                             : $this->translate('diff'),
                         $this->hyperlink($this->translate('hist'), $this->url(
-                            $isTalk ? 'scripto-talk-revision' : 'scripto-revision',
+                            $isTalk ? 'site/scripto-talk-revision' : 'site/scripto-revision',
                             [
                                 'action' => 'browse',
                                 'project-id' => $project->id(),

--- a/view/scripto/public-app/user/watchlist.phtml
+++ b/view/scripto/public-app/user/watchlist.phtml
@@ -45,7 +45,7 @@ $this->scripto()->postTitle($this->translate('Your watchlist'));
                 <td>
                     <?php echo $sMedia
                     ? $this->hyperlink($date, $this->url(
-                        $isTalk ? 'scripto-talk-revision-id' : 'scripto-revision-id',
+                        $isTalk ? 'site/scripto-talk-revision-id' : 'site/scripto-revision-id',
                         [
                             'action' => 'show',
                             'project-id' => $project->id(),
@@ -63,7 +63,7 @@ $this->scripto()->postTitle($this->translate('Your watchlist'));
                         '(%s | %s)',
                         $page['old_revid']
                             ? $this->hyperlink($this->translate('diff'), $this->url(
-                                $isTalk ? 'scripto-talk-revision-compare' : 'scripto-revision-compare',
+                                $isTalk ? 'site/scripto-talk-revision-compare' : 'site/scripto-revision-compare',
                                 [
                                     'action' => 'compare',
                                     'project-id' => $project->id(),
@@ -76,7 +76,7 @@ $this->scripto()->postTitle($this->translate('Your watchlist'));
                             ))
                             : $this->translate('diff'),
                         $this->hyperlink($this->translate('hist'), $this->url(
-                            $isTalk ? 'scripto-talk-revision' : 'scripto-revision',
+                            $isTalk ? 'site/scripto-talk-revision' : 'site/scripto-revision',
                             [
                                 'action' => 'browse',
                                 'project-id' => $project->id(),
@@ -98,7 +98,7 @@ $this->scripto()->postTitle($this->translate('Your watchlist'));
                         number_format($sizeDiff)
                     )
                 ); ?></td>
-                <td><?php echo $this->hyperlink($page['user'], $this->url('scripto-user-contributions', ['action' => 'contributions', 'user-id' => $page['user']], true)); ?></td>
+                <td><?php echo $this->hyperlink($page['user'], $this->url('site/scripto-user-contributions', ['action' => 'contributions', 'user-id' => $page['user']], true)); ?></td>
                 <td><i><?php echo strip_tags($page['parsedcomment']); ?></i></td>
             </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
It allows themes to override any view template, including the custom layout, which means they can completely customize public pages appearance.

Related issue: #87 