### PR TITLE
Fix media's original title toggle

### DIFF
--- a/asset/js/public-app.js
+++ b/asset/js/public-app.js
@@ -67,8 +67,7 @@ gridButton.click(function() {
 });
 
 // Toggle media's original titles.
-var mediaToggle = $('.title-toggle input[type="checkbox"]');
-$(document).on('change', mediaToggle, function() {
+$(document).on('change', '.title-toggle input[type="checkbox"]', function() {
    $('.original-title').toggleClass('active'); 
 });
 


### PR DESCRIPTION
The 2nd parameter of `on` should be a CSS selector, otherwise the handler is called for every `change` event on the page (for instance, changing the value of the filter select toggles the title)